### PR TITLE
fix: accept 422 validation-error responses in assertSuccessfulPrecognitiveResponses

### DIFF
--- a/src/runtime/core.ts
+++ b/src/runtime/core.ts
@@ -98,13 +98,14 @@ export function assertSuccessfulPrecognitiveResponses(
     return
   }
 
-  const check = [
-    (res: { status: number, headers: Headers }) => res?.headers?.get('Precognition') === 'true',
-    (res: { status: number, headers: Headers }) => res?.headers?.get('Precognition-Success') === 'true',
-    (res: { status: number, headers?: Headers }) => res.status === 204,
-  ].reduce((acc, fn) => acc && fn({ status: ctx.response.status, headers: ctx.response.headers }), true)
+  const { status, headers } = ctx.response
+  const hasPrecognitionHeader = headers.get('Precognition') === 'true'
+  const hasPrecognitionSuccessHeader = headers.get('Precognition-Success') === 'true'
 
-  if (check === false) {
+  const isSuccess = hasPrecognitionHeader && hasPrecognitionSuccessHeader && status === 204
+  const isValidationError = hasPrecognitionHeader && status === 422
+
+  if (!(isSuccess || isValidationError)) {
     throw createError({ message: 'Did not receive a Precognition response. Ensure you have the Precognition middleware in place for the route and Precognitive headers have been enabled in config/cors.php.', statusCode: 500 })
   }
 }

--- a/test/unit/core.test.ts
+++ b/test/unit/core.test.ts
@@ -115,6 +115,22 @@ describe('test core functions', () => {
     }).not.toThrow()
   })
 
+  it('assertSuccessfulPrecognitiveResponses does not throw when precognition header is set on response and request and response return validation errors with status 422', () => {
+    const ctx = {
+      options: { headers: { Precognition: 'true' } },
+      response: new Response(
+        null,
+        {
+          headers: { 'Precognition': 'true' },
+          status: 422,
+        },
+      ),
+    }
+    expect(() => {
+      assertSuccessfulPrecognitiveResponses(ctx)
+    }).not.toThrow()
+  })
+
   it.each([
     new Response(null, { status: 204 }),
     new Response(null, { headers: { Precognition: 'true' }, status: 204 }),


### PR DESCRIPTION
### Description
This patch updates the assertSuccessfulPrecognitiveResponses helper to recognize both valid precognitive outcomes—success handshakes and validation failures—rather than only allowing 204 responses.

**Changes**

- Retain original signature and initial precognition check.
- Introduce two boolean guards:
  - **isSuccess**: `status === 204` && both `Precognition` & `Precognition-Success` headers are `true`. 
  - **isValidationError**: `status === 422` && `Precognition` header is `true`.
- Throw a 500 error only if neither guard passes.

### Why
By design, Laravel returns a **422 Unprocessable Entity** with `Precognition: true` on validation failures. The previous implementation treated this as an unexpected response, causing spurious 500 errors in consuming clients. This update ensures that both the 204 success handshake and the 422 validation-error response are accepted as valid precognitive responses.

Fixes #3 